### PR TITLE
Fixed Actions failing to install GLFW dependencies

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,7 +46,7 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/build
       if: matrix.platform == 'ubuntu-20.04'
-      run: sudo apt-get install xorg-dev libglu1-mesa-dev
+      run: sudo apt update && sudo apt-get install xorg-dev libglu1-mesa-dev
     
     - name: Install Qt
       uses: jurplel/install-qt-action@v2.9.0


### PR DESCRIPTION
By simply running `apt update` before the install.